### PR TITLE
check if twitter script is already loaded - #33

### DIFF
--- a/src/twitterWidget.service.js
+++ b/src/twitterWidget.service.js
@@ -28,11 +28,19 @@ function TwitterWidgetFactory($document, $http, ngTweetLogger, twitterWidgetURL,
         }($document[0], 'script', 'twitter-wjs'));
     }
 
+    function checkScriptLoaded() {
+        return $window.twttr && $window.twttr.init;
+    }
+
     function loadScript() {
         if (!angular.isUndefined(deferred)) {
             return deferred.promise;
         }
         deferred = $q.defer();
+        if (checkScriptLoaded()) {
+            return deferred.resolve($window.twttr);
+        }
+
         startScriptLoad();
         $window.twttr.ready(function onLoadTwitterScript(twttr) {
             ngTweetLogger.debug('Twitter script ready');


### PR DESCRIPTION
If twitter script is already loaded in somewhere not by ngtweet itself, 
`$window.twttr.ready` is not going to trigger the callback.

This PR addresses this issue - https://github.com/arusahni/ngtweet/issues/33